### PR TITLE
Allow disturbance inputs from any module

### DIFF
--- a/CBM_dataPrep.R
+++ b/CBM_dataPrep.R
@@ -180,7 +180,7 @@ defineModule(sim, list(
         "Input `disturbanceRasters` are aligned with the `masterRaster`",
         "and the events are summarized into this table.")),
     createsOutput(
-      objectName = "disturbanceMeta", objectClass = "data.frame",
+      objectName = "disturbanceMeta", objectClass = "data.table",
       desc = "Table defining the disturbance event types.")
   )
 ))

--- a/CBM_dataPrep.R
+++ b/CBM_dataPrep.R
@@ -112,9 +112,9 @@ defineModule(sim, list(
         eventID             = "Event type ID",
         disturbance_type_id = "CBM-CFS3 disturbance type ID. If not provided, the user will be prompted to choose IDs.",
         name                = "Disturbance name (e.g. 'Wildfire'). Required only if 'disturbance_type_id' absent.",
-        delay               = "Optional. Delay (in years) of when the disturbanceRasters` source will take effect",
-        sourceValue         = "Optional. Value in the `disturbanceRasters` object to include as events",
-        objectName          = "Optional. Name of the object in the `simList` to retrieve the disturbances from annually."
+        sourceValue         = "Optional. Value in `disturbanceRasters` to include as events",
+        sourceDelay         = "Optional. Delay (in years) of when the `disturbanceRasters` will take effect",
+        sourceObjectName    = "Optional. Name of the object in the `simList` to retrieve the `disturbanceRasters` from annually."
       )),
     expectsInput(
       objectName = "disturbanceMetaURL", objectClass = "character", desc = "URL for `disturbanceMeta`"),
@@ -214,10 +214,10 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
       }else distRasts <- list()
 
       # Retrieve disturbances from simList
-      for (i in which(!is.na(sim$disturbanceMeta$objectName))){
+      for (i in which(!is.na(sim$disturbanceMeta$sourceObjectName))){
 
         distRasts[[as.character(sim$disturbanceMeta[i,]$eventID)]] <- get(
-          sim$disturbanceMeta[i,]$objectName, envir = sim)
+          sim$disturbanceMeta[i,]$sourceObjectName, envir = sim)
       }
 
       # Summarize year events into a table
@@ -251,7 +251,7 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
 
             sim$disturbanceEvents <- rbind(sim$disturbanceEvents, data.table::data.table(
               pixelIndex = eventIndex,
-              year       = as.integer(time(sim) + c(na.omit(distMeta$delay), 0)[[1]]),
+              year       = as.integer(time(sim) + c(na.omit(distMeta$sourceDelay), 0)[[1]]),
               eventID    = eventIDs[[i]]
             ))
           }

--- a/CBM_dataPrep.R
+++ b/CBM_dataPrep.R
@@ -111,7 +111,8 @@ defineModule(sim, list(
       columns = c(
         eventID             = "Event type ID",
         disturbance_type_id = "Optional. CBM-CFS3 disturbance type ID. If not provided, the user will be prompted to choose IDs.",
-        name                = "Optional. Disturbance name (e.g. 'Wildfire'). Required if 'disturbance_type_id' absent."
+        name                = "Optional. Disturbance name (e.g. 'Wildfire'). Required if 'disturbance_type_id' absent.",
+        objectName          = "Optional. Name of the object in the `simList` to retrieve the disturbances from annually."
       )),
     expectsInput(
       objectName = "disturbanceMetaURL", objectClass = "character", desc = "URL for `disturbanceMeta`"),
@@ -201,14 +202,29 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
 
     readDisturbances = {
 
+      # Get disturbances for the year
       if (length(sim$disturbanceRasters) > 0){
 
-        eventIDs <- names(sim$disturbanceRasters)
-        if (is.null(eventIDs))    stop("disturbanceRasters list names must be disturbance event IDs")
-        if (any(is.na(eventIDs))) stop("disturbanceRasters list names contains NAs")
+        distRasts <- lapply(sim$disturbanceRasters, function(d){
+          if (as.character(time(sim)) %in% names(d)) d[[as.character(time(sim))]]
+        })
+        distRasts <- distRasts[!sapply(distRasts, is.null)]
 
-        eventIDs <- suppressWarnings(tryCatch(as.integer(eventIDs), error = function(e) stop(
-          "disturbanceRasters list names must be coercible to integer")))
+      }else distRasts <- list()
+
+      # Retrieve disturbances from simList
+      for (i in which(!is.na(sim$disturbanceMeta$objectName))){
+
+        distRasts[[as.character(sim$disturbanceMeta[i,]$eventID)]] <- get(
+          sim$disturbanceMeta[i,]$objectName, envir = sim)
+      }
+
+      # Summarize year events into a table
+      if (length(distRasts) > 0){
+
+        if (is.null(names(distRasts)))    stop("disturbanceRasters list names must be disturbance event IDs")
+        if (any(is.na(names(distRasts)))) stop("disturbanceRasters list names contains NAs")
+        if (any(names(distRasts) == ""))  stop("disturbanceRasters list names contains empty strings")
 
         if (is.null(sim$disturbanceEvents)){
           sim$disturbanceEvents <- data.table::data.table(
@@ -218,31 +234,31 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
           )
         }
 
-        # Summarize year events into a table
-        for (i in 1:length(sim$disturbanceRasters)){
-          if (as.character(time(sim)) %in% names(sim$disturbanceRasters[[i]])){
+        eventIDs <- suppressWarnings(tryCatch(
+          as.integer(names(distRasts)),
+          error = function(e) stop("disturbanceRasters list names must be coercible to integer")))
 
-            distAlign <- prepInputsToMasterRaster(
-              sim$disturbanceRasters[[i]][[as.character(time(sim))]],
-              sim$masterRaster
-            ) |> Cache()
+        for (i in 1:length(distRasts)){
+          distAlign <- prepInputsToMasterRaster(
+            distRasts[[i]],
+            sim$masterRaster
+          ) |> Cache()
 
-            eventIndex <- which(!is.na(terra::values(distAlign)[,1]))
-            if (length(eventIndex) > 0){
-              sim$disturbanceEvents <- rbind(sim$disturbanceEvents, data.table::data.table(
-                pixelIndex = eventIndex,
-                year       = as.integer(time(sim)),
-                eventID    = eventIDs[[i]]
-              ))
-            }
+          eventIndex <- which(!is.na(terra::values(distAlign)[,1]))
+          if (length(eventIndex) > 0){
+            sim$disturbanceEvents <- rbind(sim$disturbanceEvents, data.table::data.table(
+              pixelIndex = eventIndex,
+              year       = as.integer(time(sim)),
+              eventID    = eventIDs[[i]]
+            ))
+          }
 
-            if (P(sim)$saveRasters){
-              outPath <- file.path(
-                outputPath(sim), "CBM_dataPrep",
-                sprintf("distRast_%s-%s_%s.tif", i, eventIDs[[i]], time(sim)))
-              dir.create(dirname(outPath), recursive = TRUE, showWarnings = FALSE)
-              terra::writeRaster(distAlign, outPath, overwrite = TRUE)
-            }
+          if (P(sim)$saveRasters){
+            outPath <- file.path(
+              outputPath(sim), "CBM_dataPrep",
+              sprintf("distRast_%s-%s_%s.tif", i, eventIDs[[i]], time(sim)))
+            dir.create(dirname(outPath), recursive = TRUE, showWarnings = FALSE)
+            terra::writeRaster(distAlign, outPath, overwrite = TRUE)
           }
         }
       }

--- a/CBM_dataPrep.R
+++ b/CBM_dataPrep.R
@@ -208,7 +208,6 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
         distRasts <- lapply(sim$disturbanceRasters, function(d){
           if (as.character(time(sim)) %in% names(d)) d[[as.character(time(sim))]]
         })
-        distRasts <- distRasts[!sapply(distRasts, is.null)]
 
       }else distRasts <- list()
 
@@ -220,6 +219,7 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
       }
 
       # Summarize year events into a table
+      distRasts <- distRasts[!sapply(distRasts, is.null)]
       if (length(distRasts) > 0){
 
         if (is.null(names(distRasts)))    stop("disturbanceRasters list names must be disturbance event IDs")

--- a/tests/testthat/test-2-module_1-SK-small.R
+++ b/tests/testthat/test-2-module_1-SK-small.R
@@ -41,8 +41,10 @@ test_that("Module: SK-small", {
       # Set disturbances
       ## Test matching user disturbances with CBM-CFS3 disturbances
       disturbanceMeta = rbind(
-        data.frame(eventID = 1, wholeStand = 1, name = "Wildfire", objectName = NA_character_),
-        data.frame(eventID = 2, wholeStand = 1, name = "Clearcut harvesting without salvage", objectName = "clearcut")
+        data.frame(eventID = 1, wholeStand = 1, name = "Wildfire",
+                   objectName = NA_character_, delay = 1),
+        data.frame(eventID = 2, wholeStand = 1, name = "Clearcut harvesting without salvage",
+                   objectName = "clearcut", delay = NA_integer_)
       ),
       disturbanceRasters = list(
         `1` = list(
@@ -137,7 +139,7 @@ test_that("Module: SK-small", {
   expect_identical(names(distEvents), c("1", "2"))
 
   expect_equal(distEvents[["1"]], rbind(
-    data.table(pixelIndex = 1, year = 1998, eventID = 1)
+    data.table(pixelIndex = 1, year = 1999, eventID = 1)
   ))
 
   expect_equal(distEvents[["2"]], rbind(

--- a/tests/testthat/test-2-module_1-SK-small.R
+++ b/tests/testthat/test-2-module_1-SK-small.R
@@ -42,9 +42,9 @@ test_that("Module: SK-small", {
       ## Test matching user disturbances with CBM-CFS3 disturbances
       disturbanceMeta = rbind(
         data.frame(eventID = 1, wholeStand = 1, name = "Wildfire",
-                   objectName = NA_character_, delay = 1),
+                   sourceValue = 1, sourceDelay = 1, sourceObjectName = NA_character_),
         data.frame(eventID = 2, wholeStand = 1, name = "Clearcut harvesting without salvage",
-                   objectName = "clearcut", delay = NA_integer_)
+                   sourceValue = NA_integer_, sourceDelay = NA_integer_, sourceObjectName = "clearcut")
       ),
       disturbanceRasters = list(
         `1` = list(
@@ -52,7 +52,7 @@ test_that("Module: SK-small", {
             crs        = "EPSG:3979",
             extent     = c(xmin = -687696, xmax = -681036, ymin = 711955, ymax = 716183),
             resolution = 30,
-            vals       = c(1, rep(NA, 31301))
+            vals       = c(1, 2, rep(NA, 31300))
         ))),
       clearcut = terra::rast(
         crs        = "EPSG:3979",


### PR DESCRIPTION
Proposing this as a solution for having disturbances provided by any module.

I've added a column called "objectName" to `disturbanceMeta` that instructs the module to look in the `simList` for an object of this name every year, and if found, use as the `disturbanceRasters` source for events of that ID.

I expanded the module test to include an example of providing disturbances 2 ways at the same time:
1. Fires are provided in the `disturbanceRasters` object with one layer for year 1998
2. Clearcuts are taken from the "clearcut" object in the simList every year. In this example, the object remains the same throughout the whole simulation, so the clearcut events are the same for all years of the simulation (1998, 1999, 2000)

Interested in any feedback or better solutions!!