### PR TITLE
adminLocator added to inputs; spuLocator removed

### DIFF
--- a/tests/testthat/test-2-module_1-SK-small.R
+++ b/tests/testthat/test-2-module_1-SK-small.R
@@ -83,7 +83,7 @@ test_that("Module: SK-small", {
   expect_true(!is.null(simTest$standDT))
   expect_true(inherits(simTest$standDT, "data.table"))
 
-  for (colName in c("pixelIndex", "area", "spatial_unit_id")){
+  for (colName in c("pixelIndex", "area", "admin_name", "admin_boundary_id", "ecozone", "spatial_unit_id")){
     expect_true(colName %in% names(simTest$standDT))
     expect_true(all(!is.na(simTest$standDT[[colName]])))
   }


### PR DESCRIPTION
This PR introduces Stats Can's administrative boundary polygons as a default input and removed the `spuLocator` Shapefile from the inputs.

`standDT` gets 2 additional columns:
- `admin_name`: the full English province or territory name (perhaps `locale_id` could be a future additional parameter to switch to French)
- `admin_boundary_id` the CBM-CFS3 defaults database admin boundary ID

The `standDT$spatial_unit_id` column is now joined in via the defaults database `spatial_units` table using the `admin_boundary_id` and `ecozone` (eco_boundary_id) fields.

@camillegiuliano this sets us up well to update the `userGcSPU` object (`userGcs`? `userGcLocations`?) in CBM_vol2biomass to use the admin & ecozone fields instead of spatial_unit_id.