### PR TITLE
standDT "admin_abbrev" column added; "admin_name" excluded from result

### DIFF
--- a/CBM_dataPrep.R
+++ b/CBM_dataPrep.R
@@ -135,8 +135,8 @@ defineModule(sim, list(
       columns = c(
         pixelIndex         = "`masterRaster` cell index",
         area               = "`masterRaster` cell area in meters",
-        admin_name         = "Canada administrative boundary name extracted from `adminLocator`",
-        admin_boundary_id  = "CBM-CFS3 administrative boundary ID extracted from `adminLocator`",
+        admin_abbrev       = "Canada administrative abbreviation extracted from `adminLocator`",
+        admin_boundary_id  = "CBM-CFS3 administrative boundary ID",
         ecozone            = "Canada ecozone ID extracted from `ecoLocator`",
         spatial_unit_id    = "CBM-CFS3 spatial unit ID"
       )),
@@ -407,6 +407,25 @@ Init <- function(sim) {
         by = "admin_boundary_id", all.x = TRUE)
     }
 
+    # Set admin abbreviation
+    allPixDT$admin_abbrev <- c(
+      "Newfoundland"              = "NL",
+      "Labrador"                  = "NL",
+      "Newfoundland and Labrador" = "NL",
+      "Prince Edward Island"      = "PE",
+      "Nova Scotia"               = "NS",
+      "New Brunswick"             = "NB",
+      "Quebec"                    = "QC",
+      "Ontario"                   = "ON",
+      "Manitoba"                  = "MB",
+      "Alberta"                   = "AB",
+      "Saskatchewan"              = "SK",
+      "British Columbia"          = "BC",
+      "Yukon"                     = "YT",
+      "Yukon Territory"           = "YT",
+      "Northwest Territories"     = "NT",
+      "Nunavut"                   = "NU")[allPixDT$admin_name] |> unname()
+
     # Set CBM-CFS3 spatial_unit_id
     allPixDT <- merge(
       allPixDT,
@@ -444,13 +463,15 @@ Init <- function(sim) {
 
   # Create sim$standDT and sim$cohortDT
   sim$standDT <- allPixDT[, .SD, .SDcols = intersect(
-    c("pixelIndex", "area", "admin_name", "admin_boundary_id", "ecozone", "spatial_unit_id"), names(allPixDT))]
+    c("pixelIndex", "area", "admin_abbrev", "admin_boundary_id", "ecozone", "spatial_unit_id"),
+    names(allPixDT))]
   data.table::setkey(sim$standDT, pixelIndex)
 
   if (is.null(sim$cohortDT)){
     allPixDT[, cohortID := pixelIndex]
     sim$cohortDT <- allPixDT[, .SD, .SDcols = intersect(
-      c("cohortID", "pixelIndex", "ages", "ageSpinup", "gcids", names(sim$cohortLocators)), names(allPixDT))]
+      c("cohortID", "pixelIndex", "ages", "ageSpinup", "gcids", names(sim$cohortLocators)),
+      names(allPixDT))]
     data.table::setkey(sim$cohortDT, cohortID)
   }
 

--- a/tests/testthat/test-2-module_1-SK-small.R
+++ b/tests/testthat/test-2-module_1-SK-small.R
@@ -83,7 +83,7 @@ test_that("Module: SK-small", {
   expect_true(!is.null(simTest$standDT))
   expect_true(inherits(simTest$standDT, "data.table"))
 
-  for (colName in c("pixelIndex", "area", "admin_name", "admin_boundary_id", "ecozone", "spatial_unit_id")){
+  for (colName in c("pixelIndex", "area", "admin_abbrev", "admin_boundary_id", "ecozone", "spatial_unit_id")){
     expect_true(colName %in% names(simTest$standDT))
     expect_true(all(!is.na(simTest$standDT[[colName]])))
   }
@@ -93,7 +93,8 @@ test_that("Module: SK-small", {
   expect_equal(nrow(simTest$standDT), 31302)
   expect_equal(simTest$standDT$pixelIndex, 1:31302)
   expect_in(simTest$standDT$area,              30 * 30)
-  expect_in(simTest$standDT$admin_name,        "Saskatchewan")
+  #expect_in(simTest$standDT$admin_name,        "Saskatchewan") # Column excluded from result
+  expect_in(simTest$standDT$admin_abbrev,      "SK")
   expect_in(simTest$standDT$admin_boundary_id, 9)
   expect_in(simTest$standDT$ecozone,           9)
   expect_in(simTest$standDT$spatial_unit_id,   28)

--- a/tests/testthat/test-2-module_2-RIA-small.R
+++ b/tests/testthat/test-2-module_2-RIA-small.R
@@ -60,7 +60,7 @@ test_that("Module: RIA-small", {
   expect_true(!is.null(simTest$standDT))
   expect_true(inherits(simTest$standDT, "data.table"))
 
-  for (colName in c("pixelIndex", "area", "admin_name", "admin_boundary_id", "ecozone", "spatial_unit_id")){
+  for (colName in c("pixelIndex", "area", "admin_abbrev", "admin_boundary_id", "ecozone", "spatial_unit_id")){
     expect_true(colName %in% names(simTest$standDT))
     expect_true(all(!is.na(simTest$standDT[[colName]])))
   }
@@ -70,7 +70,8 @@ test_that("Module: RIA-small", {
   expect_equal(nrow(simTest$standDT), 160000)
   expect_equal(simTest$standDT$pixelIndex, 1:160000)
   expect_in(simTest$standDT$area,              250*250)
-  expect_in(simTest$standDT$admin_name,        "British Columbia")
+  #expect_in(simTest$standDT$admin_name,        "British Columbia") # Column excluded from result
+  expect_in(simTest$standDT$admin_abbrev,      "BC")
   expect_in(simTest$standDT$admin_boundary_id, 11)
   expect_in(simTest$standDT$ecozone,           c(4, 9, 12, 14))
   expect_in(simTest$standDT$spatial_unit_id,   c(38, 39, 40, 42))


### PR DESCRIPTION
As discussed in #4

the "admin_name" column is now excluded from the output `standDT` table but it's present in the input data (and interim `allPixDT` table) which makes it easy to add back in if we ever need to. We would just have to add it back to the list of column names to return.