### PR TITLE
NTEMS disturbances available to module

### DIFF
--- a/CBM_dataPrep.R
+++ b/CBM_dataPrep.R
@@ -315,7 +315,7 @@ doEvent.CBM_dataPrep <- function(sim, eventTime, eventType, debug = FALSE) {
         ),
         data.table(
           eventID             = 1002L,
-          disturbance_type_id = 7, # Deforestation
+          disturbance_type_id = 204, # Clearcut harvesting without salvage
           name                = "NTEMS CA Forest Harvest 1985-2020",
           url                 = "https://opendata.nfis.org/downloads/forest_change/CA_Forest_Harvest_1985-2020.zip"
         )

--- a/tests/testthat/test-2-module_2-RIA-small.R
+++ b/tests/testthat/test-2-module_2-RIA-small.R
@@ -36,7 +36,10 @@ test_that("Module: RIA-small", {
         extent     = c(xmin = -1653000, xmax = -1553000, ymin = 1180000, ymax = 1280000),
         resolution = 250,
         vals       = 1
-      )
+      ),
+
+      # Set disturbances
+      disturbanceSource = "NTEMS"
     )
   )
 
@@ -96,13 +99,31 @@ test_that("Module: RIA-small", {
 
   ## Check output 'disturbanceMeta' ----
 
-  expect_true(is.null(simTest$disturbanceMeta))
+  expect_true(!is.null(simTest$disturbanceMeta))
+  expect_true(inherits(simTest$disturbanceMeta, "data.table"))
+
+  expect_equal(nrow(simTest$disturbanceMeta), 2)
+
+  # Check that disturbances have been matched correctly
+  expect_equal(simTest$disturbanceMeta$disturbance_type_id, c(1, 204))
 
 
   ## Check output 'disturbanceEvents' ----
 
-  expect_true(is.null(simTest$disturbanceEvents))
+  expect_true(!is.null(simTest$disturbanceEvents))
+  expect_true(inherits(simTest$disturbanceEvents, "data.table"))
 
+  for (colName in c("pixelIndex", "year", "eventID")){
+    expect_true(colName %in% names(simTest$disturbanceEvents))
+    expect_true(is.integer(simTest$disturbanceEvents[[colName]]))
+    expect_true(all(!is.na(simTest$disturbanceEvents[[colName]])))
+  }
+
+  distEventCount <- simTest$disturbanceEvents[, .(N = .N), by = c("eventID")]
+  expect_equal(distEventCount, rbind(
+    data.table(eventID = 1001, N = 2138),
+    data.table(eventID = 1002, N = 4681)
+  ))
 })
 
 

--- a/tests/testthat/test-2-module_2-RIA-small.R
+++ b/tests/testthat/test-2-module_2-RIA-small.R
@@ -123,7 +123,7 @@ test_that("Module: RIA-small", {
   expect_equal(distEventCount, rbind(
     data.table(eventID = 1001, N = 2138),
     data.table(eventID = 1002, N = 4681)
-  ))
+  ), tolerance = 100, scale = 1)
 })
 
 


### PR DESCRIPTION
This update allows the user to use NTEMS 'CA Forest Fires 1985-2020' and 'CA Forest Harvest 1985-2020' GeoTIFF layers as disturbances. This is done by setting input `disturbanceSource = "NTEMS"`.

@cboisvenue can you confirm if these are the correct disturbance types to assign to these layers? For harvest: would it be better to use 204: "Clearcut harvesting without salvage"? More info on this layer [here under "CA Forest Harvest 1985-2020"](https://opendata.nfis.org/mapserver/nfis-change_eng.html).

- CA Forest Fires 1985-2020: disturbance_type_id = 1: "Wildfire": Wildfire causing stand mortality.
- CA Forest Harvest 1985-2020: disturbance_type_id = 7: "Deforestation": The conversion of forested land to a nonforest land use, for example, forest to agricultural land.

@cboisvenue do we want to go ahead and use this as the default disturbance source we use in our SK runs? This gives us disturbances up to the year 2020. If so, I will need to update our `spadesCBM` globals to use this instead of our disturbanceRastersURL. @camillegiuliano this would mean we don't need to worry about using those other TIF and SHP files on Google Drive. However, I think we could consider continuing to use the "disturbance_testArea" rasters in testing and perhaps our example scripts for spadesCBM newbies.

I have noticed that these layers offer only one 1 disturbance per pixel: the date of the most recent disturbance. This isn't ideal for our purposes since we'd want to have the full disturbance history available at any given location. Pinned for a later discussion on comparing data sources.